### PR TITLE
build: produce Windows GUI build with Cirrus CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -102,6 +102,52 @@ task:
     FILE_ENV: "./ci/test/00_setup_env_win64.sh"
 
 task:
+  name: 'Win64 [installer]'
+  timeout_in: 120m
+  windows_container:
+    image: cirrusci/windowsservercore:2019
+    cpu: 8
+    memory: 16G
+  clone_script:
+    - choco install -y git
+    - cd c:\
+    - git clone -b %CIRRUS_BRANCH% %CIRRUS_REPO_CLONE_URL%
+  install_script:
+    # Install Vistual Studio build tools and other prerequisites
+    - choco upgrade -y visualstudio2019-workload-vctools
+    - choco install -y python3
+  install_vcpkgs_script:
+    # Add vcpkg packages
+    - git clone https://github.com/microsoft/vcpkg
+    - .\vcpkg\bootstrap-vcpkg.bat
+    - .\vcpkg\vcpkg integrate install
+    - .\vcpkg\vcpkg install boost-process:x64-windows-static boost-variant:x64-windows-static boost-signals2:x64-windows-static boost-multi-index:x64-windows-static boost-test:x64-windows-static
+    - .\vcpkg\vcpkg install libevent:x64-windows-static sqlite3:x64-windows-static
+    - .\vcpkg\vcpkg install berkeleydb:x64-windows-static curl:x64-windows-static
+    - .\vcpkg\vcpkg install zeromq:x64-windows-static rapidcheck:x64-windows-static
+  add_qt_script:
+    # Add Qt libraries
+    - choco install -y wget
+    - wget https://github.com/sipsorcery/qt_win_binary/releases/download/qt598x64_vs2019_v1681/qt598_x64_vs2019_1681.zip
+    - unzip qt598_x64_vs2019_1681.zip -d c:\Qt5.9.8_x64_static_vs2019
+  build_script:
+    # Build bitcoin
+    - cd c:\bitcoin\build_msvc
+    - py msvc-autogen.py
+    - '"c:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin\msbuild" bitcoin.sln'
+  prepare_installer_script:
+    # Install NSIS and prepare msi package
+    - choco install -y nsis
+    - mkdir c:\binaries_windows
+    - cp c:\bitcoin\build_msvc\x64\Debug\bitcoind.exe c:\binaries_windows
+    - cp c:\bitcoin\build_msvc\x64\Debug\bitcoin-tx.exe c:\binaries_windows
+    - cp c:\bitcoin\build_msvc\x64\Debug\bitcoin-qt.exe c:\binaries_windows
+    - cp c:\bitcoin\build_msvc\x64\Debug\bitcoin-cli.exe c:\binaries_windows
+    - cp c:\bitcoin\build_msvc\x64\Debug\bitcoin-wallet.exe c:\binaries_windows
+    - cd c:\bitcoin\share
+    - '"c:\Program Files (x86)\NSIS\makensis.exe" setup-bitcoin-win.nsi'
+
+task:
   name: '32-bit + dash [gui] [CentOS 8]'
   << : *GLOBAL_TASK_TEMPLATE
   container:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -110,7 +110,7 @@ task:
     memory: 16G
   env:
     CIRRUS_WORKING_DIR: "C:\\Windows\\Temp\\bitcoin"
-  install_script:\
+  install_script:
     # Install Vistual Studio build tools and other prerequisites
     - choco upgrade -y visualstudio2019-workload-vctools
     - choco install -y python3

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -119,17 +119,19 @@ task:
   install_vcpkgs_script:
     # Add vcpkg packages
     - git clone https://github.com/microsoft/vcpkg
-    - .\vcpkg\bootstrap-vcpkg.bat
-    - .\vcpkg\vcpkg integrate install
-    - .\vcpkg\vcpkg install boost-process:x64-windows-static boost-variant:x64-windows-static boost-signals2:x64-windows-static boost-multi-index:x64-windows-static boost-test:x64-windows-static
-    - .\vcpkg\vcpkg install libevent:x64-windows-static sqlite3:x64-windows-static
-    - .\vcpkg\vcpkg install berkeleydb:x64-windows-static curl:x64-windows-static
-    - .\vcpkg\vcpkg install zeromq:x64-windows-static rapidcheck:x64-windows-static
+    - cd vcpkg
+    - git checkout 75522bb1f2e7d863078bcd06322348f053a9e33f
+    - .\bootstrap-vcpkg.bat
+    - .\vcpkg integrate install
+    - .\vcpkg install boost-process:x64-windows-static boost-variant:x64-windows-static boost-signals2:x64-windows-static boost-multi-index:x64-windows-static boost-test:x64-windows-static
+    - .\vcpkg install libevent:x64-windows-static sqlite3:x64-windows-static
+    - .\vcpkg install berkeleydb:x64-windows-static curl:x64-windows-static
+    - .\vcpkg install zeromq:x64-windows-static rapidcheck:x64-windows-static
   add_qt_script:
     # Add Qt libraries
     - choco install -y wget
-    - wget https://github.com/sipsorcery/qt_win_binary/releases/download/qt598x64_vs2019_v1681/qt598_x64_vs2019_1681.zip
-    - unzip qt598_x64_vs2019_1681.zip -d c:\Qt5.9.8_x64_static_vs2019
+    - wget https://github.com/sipsorcery/qt_win_binary/releases/download/qt51210x64_vs2019_1694/Qt5.12.10_x64_static_vs2019_1694.zip
+    - unzip Qt5.12.10_x64_static_vs2019_1694.zip -d c:\Qt5.12.10_x64_static_vs2019_1694
   build_script:
     # Build bitcoin
     - cd c:\bitcoin\build_msvc

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -102,16 +102,14 @@ task:
     FILE_ENV: "./ci/test/00_setup_env_win64.sh"
 
 task:
+  env:
+    CIRRUS_WORKING_DIR: "c:\\"
   name: 'Win64 [installer]'
   timeout_in: 120m
   windows_container:
     image: cirrusci/windowsservercore:2019
     cpu: 8
     memory: 16G
-  clone_script:
-    - choco install -y git
-    - cd c:\
-    - git clone -b %CIRRUS_BRANCH% %CIRRUS_REPO_CLONE_URL%
   install_script:
     # Install Vistual Studio build tools and other prerequisites
     - choco upgrade -y visualstudio2019-workload-vctools

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -102,15 +102,15 @@ task:
     FILE_ENV: "./ci/test/00_setup_env_win64.sh"
 
 task:
-  env:
-    CIRRUS_WORKING_DIR: "c:\\"
   name: 'Win64 [installer]'
   timeout_in: 120m
   windows_container:
     image: cirrusci/windowsservercore:2019
     cpu: 8
     memory: 16G
-  install_script:
+  env:
+    CIRRUS_WORKING_DIR: "C:\\Windows\\Temp\\bitcoin"
+  install_script:\
     # Install Vistual Studio build tools and other prerequisites
     - choco upgrade -y visualstudio2019-workload-vctools
     - choco install -y python3
@@ -132,19 +132,19 @@ task:
     - unzip Qt5.12.10_x64_static_vs2019_1694.zip -d c:\Qt5.12.10_x64_static_vs2019_1694
   build_script:
     # Build bitcoin
-    - cd c:\bitcoin\build_msvc
+    - cd c:\Windows\Temp\bitcoin\build_msvc
     - py msvc-autogen.py
     - '"c:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin\msbuild" bitcoin.sln'
   prepare_installer_script:
     # Install NSIS and prepare msi package
     - choco install -y nsis
     - mkdir c:\binaries_windows
-    - cp c:\bitcoin\build_msvc\x64\Debug\bitcoind.exe c:\binaries_windows
-    - cp c:\bitcoin\build_msvc\x64\Debug\bitcoin-tx.exe c:\binaries_windows
-    - cp c:\bitcoin\build_msvc\x64\Debug\bitcoin-qt.exe c:\binaries_windows
-    - cp c:\bitcoin\build_msvc\x64\Debug\bitcoin-cli.exe c:\binaries_windows
-    - cp c:\bitcoin\build_msvc\x64\Debug\bitcoin-wallet.exe c:\binaries_windows
-    - cd c:\bitcoin\share
+    - cp c:\Windows\Temp\bitcoin\build_msvc\x64\Debug\bitcoind.exe c:\binaries_windows
+    - cp c:\Windows\Temp\bitcoin\build_msvc\x64\Debug\bitcoin-tx.exe c:\binaries_windows
+    - cp c:\Windows\Temp\bitcoin\build_msvc\x64\Debug\bitcoin-qt.exe c:\binaries_windows
+    - cp c:\Windows\Temp\bitcoin\build_msvc\x64\Debug\bitcoin-cli.exe c:\binaries_windows
+    - cp c:\Windows\Temp\bitcoin\build_msvc\x64\Debug\bitcoin-wallet.exe c:\binaries_windows
+    - cd c:\Windows\Temp\bitcoin\share
     - '"c:\Program Files (x86)\NSIS\makensis.exe" setup-bitcoin-win.nsi'
 
 task:

--- a/share/setup-bitcoin-win.nsi
+++ b/share/setup-bitcoin-win.nsi
@@ -76,14 +76,14 @@ ShowUninstDetails show
 Section -Main SEC0000
     SetOutPath $INSTDIR
     SetOverwrite on
-    File ..\..\binaries_windows\bitcoin-qt.exe
+    File c:\binaries_windows\bitcoin-qt.exe
     File /oname=COPYING.txt ..\COPYING
     File /oname=readme.txt ..\doc\README_windows.txt
     SetOutPath $INSTDIR\daemon
-    File ..\..\binaries_windows\bitcoind.exe
-    File ..\..\binaries_windows\bitcoin-cli.exe
-    File ..\..\binaries_windows\bitcoin-tx.exe
-    File ..\..\binaries_windows\bitcoin-wallet.exe
+    File c:\binaries_windows\bitcoind.exe
+    File c:\binaries_windows\bitcoin-cli.exe
+    File c:\binaries_windows\bitcoin-tx.exe
+    File c:\binaries_windows\bitcoin-wallet.exe
     SetOutPath $INSTDIR\doc
     File /r /x Makefile* ..\doc\*.*
     SetOutPath $INSTDIR

--- a/share/setup-bitcoin-win.nsi
+++ b/share/setup-bitcoin-win.nsi
@@ -1,0 +1,180 @@
+!define PACKAGE_NAME "Bitcoin Core"
+Name "${PACKAGE_NAME} (64-bit)"
+
+RequestExecutionLevel highest
+SetCompressor /SOLID lzma
+SetDateSave off
+Unicode true
+
+# Uncomment these lines when investigating reproducibility errors
+#SetCompress off
+#SetDatablockOptimize off
+
+# General Symbol Definitions
+!define REGKEY "SOFTWARE\$(^Name)"
+!define PACKAGE_TARNAME "bitcoin"
+!define PACKAGE_URL "https://bitcoincore.org/"
+!define PACKAGE_VERSION "21.99.0"
+!define COMPANY "${PACKAGE_NAME} project"
+!define URL ${PACKAGE_URL}
+
+# MUI Symbol Definitions
+!define MUI_ICON "..\share\pixmaps\bitcoin.ico"
+!define MUI_WELCOMEFINISHPAGE_BITMAP "..\share\pixmaps\nsis-wizard.bmp"
+!define MUI_HEADERIMAGE
+!define MUI_HEADERIMAGE_RIGHT
+!define MUI_HEADERIMAGE_BITMAP "..\share\pixmaps\nsis-header.bmp"
+!define MUI_FINISHPAGE_NOAUTOCLOSE
+!define MUI_STARTMENUPAGE_REGISTRY_ROOT HKLM
+!define MUI_STARTMENUPAGE_REGISTRY_KEY ${REGKEY}
+!define MUI_STARTMENUPAGE_REGISTRY_VALUENAME StartMenuGroup
+!define MUI_STARTMENUPAGE_DEFAULTFOLDER "${PACKAGE_NAME}"
+!define MUI_FINISHPAGE_RUN "$WINDIR\explorer.exe"
+!define MUI_FINISHPAGE_RUN_PARAMETERS $INSTDIR\bitcoin-qt.exe
+!define MUI_UNICON "${NSISDIR}\Contrib\Graphics\Icons\modern-uninstall.ico"
+!define MUI_UNWELCOMEFINISHPAGE_BITMAP "..\share\pixmaps\nsis-wizard.bmp"
+!define MUI_UNFINISHPAGE_NOAUTOCLOSE
+
+# Included files
+!include Sections.nsh
+!include MUI2.nsh
+!include x64.nsh
+
+# Variables
+Var StartMenuGroup
+
+# Installer pages
+!insertmacro MUI_PAGE_WELCOME
+!insertmacro MUI_PAGE_DIRECTORY
+!insertmacro MUI_PAGE_STARTMENU Application $StartMenuGroup
+!insertmacro MUI_PAGE_INSTFILES
+!insertmacro MUI_PAGE_FINISH
+!insertmacro MUI_UNPAGE_CONFIRM
+!insertmacro MUI_UNPAGE_INSTFILES
+
+# Installer languages
+!insertmacro MUI_LANGUAGE English
+
+# Installer attributes
+InstallDir $PROGRAMFILES64\Bitcoin
+CRCCheck on
+XPStyle on
+BrandingText " "
+ShowInstDetails show
+VIProductVersion "${PACKAGE_VERSION}.0"
+VIAddVersionKey ProductName "${PACKAGE_NAME}"
+VIAddVersionKey ProductVersion "${PACKAGE_VERSION}"
+VIAddVersionKey CompanyName "${COMPANY}"
+VIAddVersionKey CompanyWebsite "${URL}"
+VIAddVersionKey FileVersion "${PACKAGE_VERSION}"
+VIAddVersionKey FileDescription "Installer for ${PACKAGE_NAME}"
+VIAddVersionKey LegalCopyright ""
+InstallDirRegKey HKCU "${REGKEY}" Path
+ShowUninstDetails show
+
+# Installer sections
+Section -Main SEC0000
+    SetOutPath $INSTDIR
+    SetOverwrite on
+    File ..\..\binaries_windows\bitcoin-qt.exe
+    File /oname=COPYING.txt ..\COPYING
+    File /oname=readme.txt ..\doc\README_windows.txt
+    SetOutPath $INSTDIR\daemon
+    File ..\..\binaries_windows\bitcoind.exe
+    File ..\..\binaries_windows\bitcoin-cli.exe
+    File ..\..\binaries_windows\bitcoin-tx.exe
+    File ..\..\binaries_windows\bitcoin-wallet.exe
+    SetOutPath $INSTDIR\doc
+    File /r /x Makefile* ..\doc\*.*
+    SetOutPath $INSTDIR
+    WriteRegStr HKCU "${REGKEY}\Components" Main 1
+SectionEnd
+
+Section -post SEC0001
+    WriteRegStr HKCU "${REGKEY}" Path $INSTDIR
+    SetOutPath $INSTDIR
+    WriteUninstaller $INSTDIR\uninstall.exe
+    !insertmacro MUI_STARTMENU_WRITE_BEGIN Application
+    CreateDirectory $SMPROGRAMS\$StartMenuGroup
+    CreateShortcut "$SMPROGRAMS\$StartMenuGroup\$(^Name).lnk" $INSTDIR\bitcoin-qt.exe
+    CreateShortcut "$SMPROGRAMS\$StartMenuGroup\${PACKAGE_NAME} (testnet, 64-bit).lnk" "$INSTDIR\bitcoin-qt.exe" "-testnet" "$INSTDIR\bitcoin-qt.exe" 1
+    CreateShortcut "$SMPROGRAMS\$StartMenuGroup\Uninstall $(^Name).lnk" $INSTDIR\uninstall.exe
+    !insertmacro MUI_STARTMENU_WRITE_END
+    WriteRegStr HKCU "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\$(^Name)" DisplayName "$(^Name)"
+    WriteRegStr HKCU "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\$(^Name)" DisplayVersion "${PACKAGE_VERSION}"
+    WriteRegStr HKCU "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\$(^Name)" Publisher "${COMPANY}"
+    WriteRegStr HKCU "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\$(^Name)" URLInfoAbout "${URL}"
+    WriteRegStr HKCU "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\$(^Name)" DisplayIcon $INSTDIR\bitcoin-qt.exe
+    WriteRegStr HKCU "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\$(^Name)" UninstallString $INSTDIR\uninstall.exe
+    WriteRegDWORD HKCU "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\$(^Name)" NoModify 1
+    WriteRegDWORD HKCU "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\$(^Name)" NoRepair 1
+    WriteRegStr HKCR "${PACKAGE_TARNAME}" "URL Protocol" ""
+    WriteRegStr HKCR "${PACKAGE_TARNAME}" "" "URL:Bitcoin"
+    WriteRegStr HKCR "${PACKAGE_TARNAME}\DefaultIcon" "" $INSTDIR\bitcoin-qt.exe
+    WriteRegStr HKCR "${PACKAGE_TARNAME}\shell\open\command" "" '"$INSTDIR\bitcoin-qt.exe" "%1"'
+SectionEnd
+
+# Macro for selecting uninstaller sections
+!macro SELECT_UNSECTION SECTION_NAME UNSECTION_ID
+    Push $R0
+    ReadRegStr $R0 HKCU "${REGKEY}\Components" "${SECTION_NAME}"
+    StrCmp $R0 1 0 next${UNSECTION_ID}
+    !insertmacro SelectSection "${UNSECTION_ID}"
+    GoTo done${UNSECTION_ID}
+next${UNSECTION_ID}:
+    !insertmacro UnselectSection "${UNSECTION_ID}"
+done${UNSECTION_ID}:
+    Pop $R0
+!macroend
+
+# Uninstaller sections
+Section /o -un.Main UNSEC0000
+    Delete /REBOOTOK $INSTDIR\bitcoin-qt.exe
+    Delete /REBOOTOK $INSTDIR\COPYING.txt
+    Delete /REBOOTOK $INSTDIR\readme.txt
+    RMDir /r /REBOOTOK $INSTDIR\daemon
+    RMDir /r /REBOOTOK $INSTDIR\doc
+    DeleteRegValue HKCU "${REGKEY}\Components" Main
+SectionEnd
+
+Section -un.post UNSEC0001
+    DeleteRegKey HKCU "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\$(^Name)"
+    Delete /REBOOTOK "$SMPROGRAMS\$StartMenuGroup\Uninstall $(^Name).lnk"
+    Delete /REBOOTOK "$SMPROGRAMS\$StartMenuGroup\$(^Name).lnk"
+    Delete /REBOOTOK "$SMPROGRAMS\$StartMenuGroup\${PACKAGE_NAME} (testnet, 64-bit).lnk"
+    Delete /REBOOTOK "$SMSTARTUP\Bitcoin.lnk"
+    Delete /REBOOTOK $INSTDIR\uninstall.exe
+    Delete /REBOOTOK $INSTDIR\debug.log
+    Delete /REBOOTOK $INSTDIR\db.log
+    DeleteRegValue HKCU "${REGKEY}" StartMenuGroup
+    DeleteRegValue HKCU "${REGKEY}" Path
+    DeleteRegKey /IfEmpty HKCU "${REGKEY}\Components"
+    DeleteRegKey /IfEmpty HKCU "${REGKEY}"
+    DeleteRegKey HKCR "${PACKAGE_TARNAME}"
+    RmDir /REBOOTOK $SMPROGRAMS\$StartMenuGroup
+    RmDir /REBOOTOK $INSTDIR
+    Push $R0
+    StrCpy $R0 $StartMenuGroup 1
+    StrCmp $R0 ">" no_smgroup
+no_smgroup:
+    Pop $R0
+SectionEnd
+
+# Installer functions
+Function .onInit
+    InitPluginsDir
+    ${If} ${RunningX64}
+      ; disable registry redirection (enable access to 64-bit portion of registry)
+      SetRegView 64
+    ${Else}
+      MessageBox MB_OK|MB_ICONSTOP "Cannot install 64-bit version on a 32-bit system."
+      Abort
+    ${EndIf}
+FunctionEnd
+
+# Uninstaller functions
+Function un.onInit
+    ReadRegStr $INSTDIR HKCU "${REGKEY}" Path
+    !insertmacro MUI_STARTMENU_GETFOLDER Application $StartMenuGroup
+    !insertmacro SELECT_UNSECTION Main ${UNSEC0000}
+FunctionEnd


### PR DESCRIPTION

This PR is a build of Bitcoin Core for Windows with Cirrus CI. It creates executable files,
including bitcoin-qt.exe and packs them to NSIS installer .exe file.

It's built using MSVC toolchain with the solution files from build_msvc, so the
commands in the task are different than ones used in CI folder.

Please consider this as a prototype, if making builds from single CI system could
be counted as simpler approach. Some refactoring should still be required.
